### PR TITLE
Fall back to getString in case string is not spanned

### DIFF
--- a/spanomatic/src/main/java/com/grivos/spanomatic/utils/Extensions.kt
+++ b/spanomatic/src/main/java/com/grivos/spanomatic/utils/Extensions.kt
@@ -45,7 +45,9 @@ fun Context.addSpansFromAnnotations(@StringRes id: Int, vararg formatArgs: Any):
     return if (text is SpannedString) {
         val replaced = PlaceholderFormatter.format(text, *formatArgs)
         addSpansFromAnnotations(replaced, this)
-    } else text
+    } else {
+        getString(id, formatArgs)
+    }
 }
 
 fun Fragment.addSpansFromAnnotations(@StringRes id: Int, vararg formatArgs: Any): CharSequence? =


### PR DESCRIPTION
This PR aims to improve the specific scenario described below by making `addSpansFromAnnotations` mirror the behavior of `getString` and its overload on Android.

Given two strings, both with placeholders but only one having annotations, eg:
```
<string name="one">This has a bold parameter: <annotation format="bold">%1$s</annotation></string>
<string name="two">This has a regular parameter: %1$s</string>
```
It's possible that the developer might want to set a slightly differently formatted string depending on a condition:
```
val myString = "my_string"
textview.text = addSpansFromAnnotations(if (condition) R.string.one else R.string.two, myString)
```
In the current implementation, if the condition is true, the formatting will be applied properly. But if the condition is false, then the resulting string will be `This has a regular parameter: %1$s`. After these changes, the formatting will be as expected for both strings.