### PR TITLE
Increase viewpump version to prevent Android 10+ crashes

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,21 +1,12 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="USE_CUSTOM_SETTINGS" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <MarkdownNavigatorCodeStyleSettings>
       <option name="RIGHT_MARGIN" value="72" />
     </MarkdownNavigatorCodeStyleSettings>
-    <XML>
-      <option name="XML_KEEP_LINE_BREAKS" value="false" />
-      <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-      <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
-    </XML>
     <codeStyleSettings language="XML">
-      <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add these dependencies to your app module's build.gradle file:
 ```groovy
 dependencies {
     implementation 'com.grivos.spanomatic:spanomatic:1.0.1'
-    implementation 'io.github.inflationx:viewpump:1.0.0'
+    implementation 'io.github.inflationx:viewpump:2.0.3'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':spanomatic')
-    implementation 'io.github.inflationx:viewpump:1.0.0'
+    implementation 'io.github.inflationx:viewpump:2.0.3'
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
     testImplementation 'junit:junit:4.12'

--- a/spanomatic/build.gradle
+++ b/spanomatic/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'io.github.inflationx:viewpump:1.0.0'
+    implementation 'io.github.inflationx:viewpump:2.0.3'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/spanomatic/src/main/java/com/grivos/spanomatic/SpanomaticInterceptor.kt
+++ b/spanomatic/src/main/java/com/grivos/spanomatic/SpanomaticInterceptor.kt
@@ -7,7 +7,7 @@ import io.github.inflationx.viewpump.Interceptor
 class SpanomaticInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): InflateResult {
         val result = chain.proceed(chain.request())
-        val view = result.view()
+        val view = result.view
         if (view is TextView) {
             view.text = Spanomatic.addSpansFromAnnotations(view.text, view.context)
         }


### PR DESCRIPTION
Using this library I found out that Android 10 devices crashes because of viewpump low version. Increased version fixed this problem. 

Solution taken from this issue: 
https://github.com/InflationX/Calligraphy/issues/35