### PR TITLE
Migrate to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -27,8 +27,8 @@ dependencies {
     implementation project(':spanomatic')
     implementation 'io.github.inflationx:viewpump:2.0.3'
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/app/src/main/java/com/grivos/spanomatic/app/MainActivity.kt
+++ b/app/src/main/java/com/grivos/spanomatic/app/MainActivity.kt
@@ -2,7 +2,7 @@ package com.grivos.spanomatic.app
 
 import android.content.Context
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.widget.Toast
 import com.grivos.spanomatic.utils.addSpanClickListener
 import io.github.inflationx.viewpump.ViewPumpContextWrapper

--- a/app/src/main/java/com/grivos/spanomatic/app/SpanomaticApplication.kt
+++ b/app/src/main/java/com/grivos/spanomatic/app/SpanomaticApplication.kt
@@ -2,7 +2,7 @@ package com.grivos.spanomatic.app
 
 import android.app.Application
 import android.graphics.Typeface
-import android.support.v4.content.res.ResourcesCompat
+import androidx.core.content.res.ResourcesCompat
 import com.grivos.spanomatic.Spanomatic
 import com.grivos.spanomatic.SpanomaticInterceptor
 import com.grivos.spanomatic.TypefaceProvider

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.4.0'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.useAndroidX=true
+android.enableJetifier=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip

--- a/spanomatic/build.gradle
+++ b/spanomatic/build.gradle
@@ -10,7 +10,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
     }
 
@@ -26,10 +26,10 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'io.github.inflationx:viewpump:2.0.3'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation 'junit:junit:4.12'
 }

--- a/spanomatic/src/androidTest/java/com/grivos/spanomatic/ExampleInstrumentedTest.java
+++ b/spanomatic/src/androidTest/java/com/grivos/spanomatic/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.grivos.spanomatic;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -18,7 +18,7 @@ public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() {
         // Context of the app under test.
-        Context appContext = InstrumentationRegistry.getTargetContext();
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         assertEquals("com.grivos.spans.test", appContext.getPackageName());
     }

--- a/spanomatic/src/main/java/com/grivos/spanomatic/utils/Extensions.kt
+++ b/spanomatic/src/main/java/com/grivos/spanomatic/utils/Extensions.kt
@@ -1,8 +1,8 @@
 package com.grivos.spanomatic.utils
 
 import android.content.Context
-import android.support.annotation.StringRes
-import android.support.v4.app.Fragment
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
 import android.text.SpannableString
 import android.text.SpannedString
 import android.text.method.LinkMovementMethod

--- a/spanomatic/src/main/java/com/grivos/spanomatic/utils/Utils.kt
+++ b/spanomatic/src/main/java/com/grivos/spanomatic/utils/Utils.kt
@@ -2,7 +2,7 @@ package com.grivos.spanomatic.utils
 
 import android.content.Context
 import android.graphics.Color
-import android.support.v4.content.ContextCompat
+import androidx.core.content.ContextCompat
 import android.util.TypedValue
 
 fun parseAnnotationColor(colorValue: String, context: Context): Int {


### PR DESCRIPTION
Changes:
- migrate SupportV4 to AndroidX
- bump AGP to 4.0.1, Kotlin to 1.4.0
- bump test artifacts to latest

Addresses #3 